### PR TITLE
Additional DNS entry for self signed CAs

### DIFF
--- a/integrations/ssl/certs/tyk.local.ext
+++ b/integrations/ssl/certs/tyk.local.ext
@@ -9,3 +9,4 @@ DNS.2 = dashboard.tyk.local
 DNS.3 = gateway.tyk.local
 DNS.4 = dashboard-svc-tyk-pro.tyk
 DNS.5 = gateway-svc-tyk-pro.tyk
+DNS.6 = dashboard-svc-tyk-pro.tyk.svc.cluster.local


### PR DESCRIPTION
Added another DNS entry in the tyk.local.ext file in order for the inter-cluster communication to be done using our self signed certificate authority if provided (introduced with the env-var PR of the helm chart https://github.com/TykTechnologies/tyk-helm-chart/pull/205 ) 